### PR TITLE
Add bot message when win detected via Discord presence

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,6 +33,9 @@ client.on('reconnecting', () => {
 
 client.on('message', bot.onMessage);
 
+//when user changes status
+client.on('presenceUpdate', bot.presenceUpdate);
+
 //login to Discord
 client.login(CONFIG.app.DISCORD_BOT_TOKEN);
 

--- a/config.js
+++ b/config.js
@@ -1,8 +1,37 @@
 require('dotenv').config();
 const env = process.env.MODE;
 
-let good = ['Whatever you say...', `You're the boss!`, `Ok, fine!`, `:shrug:`];
-let bad = [':middle_finger:', 'Who are you again?', ':poop:', 'How bout you drink a nice glass of shut the hell up :coffee:', 'Could you fucking not?', `You're stupid and I hate you`];
+let good = [
+	'Whatever you say...', 
+	`You're the boss!`, 
+	`Ok, fine!`, 
+	`:shrug:`
+];
+let bad = [
+	':middle_finger:', 
+	'Who are you again?', 
+	':poop:', 
+	'How bout you drink a nice glass of shut the hell up :coffee:', 
+	'Could you fucking not?', 
+	`You're stupid and I hate you`
+];
+
+//[USER] is replaced by user(s) mention e.g. @PTRFRLL
+let winner = [
+	'Do I smell chicken :chicken:, [USER]?', 
+	'What\'s that smell, [USER]?', 
+	'Mmm, something smells good [USER]', 
+	'[USER], did you order Popeyes :chicken:?', 
+	'[USER] Looks like we got some winners over here :fork_knife_plate:',
+	'[USER] Look at these fucking guys :eyes:'
+];
+let spectator = [
+	'Couldn\'t make it to the end, [USER]? :skull_crossbones:', 
+	'At least you\'re light, [USER] :stuck_out_tongue_winking_eye:', 
+	'[USER] gettin carried per usual...', 
+	'[USER] for MVP :smiling_imp:', 
+	'[USER], there for moral support... :angel:'
+];
 
 const prod = {
 	app: {
@@ -12,7 +41,9 @@ const prod = {
 		LOGMODE: 'prod',
 		AUTH_USER_IDS: [''], //discord user ids
 		BOT_RESPONSES_GOOD: good,
-		BOT_RESPONSES_BAD: bad
+		BOT_RESPONSES_BAD: bad,
+		BOT_PRESENCE_RESPONSES: winner,
+		BOT_SPECTATOR_RESPONSES: spectator
 	},
 	db: {
 		DATABASE_PATH:  __dirname + '/data/db.sqlite'

--- a/lib/discord.js
+++ b/lib/discord.js
@@ -5,8 +5,6 @@ const logger = require('./log');
 const Discord = require('discord.js');
 const app = require('../app');
 const CONFIG = require('../config.js');
-module.exports.onMessage = onMessage;
-module.exports.getWins = getWins;
 
 async function onMessage(message){
 	//ignore bots
@@ -214,3 +212,67 @@ async function findMessageById(message_id){
 	logger.debug(channel);
 	return channel.fetchMessage(message_id);
 }
+
+
+let winners = [];
+let spectators = [];
+async function presenceUpdate(old, updated){
+	if(updated.presence.game != null && updated.presence.game.name === 'PLAYERUNKNOWN\'S BATTLEGROUNDS'){
+		 	if(updated.presence.game.details == null) return;
+			if(updated.presence.game.details.includes('Winner Winner Chicken Dinner!')){
+				if(old.presence.game.details.includes('Watching')){
+					logger.log(`Spectator win detected via presence for ${updated.user.username}, adding to spectators`);
+					spectators.push(updated.user);
+				}else if(!old.presence.game.details.includes('Winner Winner Chicken Dinner!')){
+					logger.log(`Win detected via presence for ${updated.user.username}, adding to winners`);
+					winners.push(updated.user);
+				}else{
+					logger.log(`Win detected for ${update.user.username} BUT old presence also a win, skipping add to array...`);
+				}
+			}
+			if(old.presence.game.details != null && old.presence.game.details.includes('Winner Winner Chicken Dinner!') && !updated.presence.game.details.includes('Winner Winner Chicken Dinner!')){
+				//players have left winner screen, send message
+				logger.log(`Post win for ${old.user.username}: [${old.presence.game.details}] => [${updated.presence.game.details}]`);
+				const channel = updated.guild.channels.get(CONFIG.app.DISCORD_CHANNEL);
+				try{
+					if(winners.length === 0) return;
+					let response = CONFIG.app.BOT_PRESENCE_RESPONSES[Math.floor(Math.random()*CONFIG.app.BOT_PRESENCE_RESPONSES.length)];
+					let winningUsers = winners.map(user => {
+						return `<@${user.id}>`;
+					});
+					response = response.replace('[USER]', winningUsers.join(' '));
+	    			channel.send(response); 
+					//clear array
+	    			winners.length = 0;
+    			}catch(e){
+    				logger.error(`Error sending winner presence response: ${e}`);
+    				//clear array
+	    			winners.length = 0;
+    			}
+    			try{
+    				if(spectators.length === 0) return;
+	    			let deadWinnersRes = CONFIG.app.BOT_SPECTATOR_RESPONSES[Math.floor(Math.random()*CONFIG.app.BOT_SPECTATOR_RESPONSES.length)];
+	    			console.log(spectators);
+	    			let spectatorUsers = spectators.map(user => {
+						return `<@${user.id}>`;
+					});
+					deadWinnersRes = deadWinnersRes.replace('[USER]', spectatorUsers.join(' '));
+	    			channel.send(deadWinnersRes);
+	    			//clear array
+	    			spectators.length = 0;
+    			}catch(e){
+    				logger.error(`Error sending spectator presence response: ${e}`);
+    				//clear array
+	    			spectators.length = 0;
+    			}
+    			
+			}	
+    }
+}
+
+
+module.exports = {
+	onMessage,
+	getWins,
+	presenceUpdate
+};


### PR DESCRIPTION
New PUBG update uses Discord Presence feature to show in-game status. Tap into these events and send a message to the winners when a win is detected. Going forward this may be a better way to count wins but for now, it's just a start using the new presence feature.