### PR TITLE
Use Presence party ID to query stats

### DIFF
--- a/lib/discord.js
+++ b/lib/discord.js
@@ -108,7 +108,8 @@ const createStatsEmbed = async(stats, username) => {
  * @param {*} displayTeam 
  * @returns 
  */
-const createWinningStatEmbed = async(stats, username, displayTeam = false) => {
+const createWinningStatEmbed = async(stats, displayTeam = false) => {
+  let username = stats.name;
   let embed = new Discord.MessageEmbed();
   embed.setTitle(`PUBG Stats`);
   embed.setColor('RANDOM');

--- a/lib/events/presence.js
+++ b/lib/events/presence.js
@@ -109,10 +109,13 @@ const detectWin = (presence) => {
  */
 const saveWinner = async(updated, winner) => {
   const id = updated.party.id;
+  logger.debug(`Found party id: ${id}`);
   if(WINNERS.has(id)){
+    logger.log(`${id} found in map, adding to team`)
     let arr = WINNERS.get(id);
     arr.push(winner);
   }else{
+    logger.log(`Not found in winners map, adding ${id}`)
     WINNERS.set(id, [winner]);
   }
 }
@@ -138,14 +141,20 @@ const isValidMap = (details) => {
  * @returns 
  */
 const handleWin = async(presence, channel) => {
-  const {user, old, updated} = presence; 
+  const {user, old, updated} = presence;
+  if(!isValidMap(updated.details)){
+    return;
+  }
   logger.log(`Post win for ${user.username}: [${old.details}] => [${updated.details}]`);
   const id = updated.party.id;
+  logger.debug(`Found party ID: ${id}`);
   if(!WINNERS.has(id)){
     logger.log(`Winners ID ${id} not found, message must have been sent already...`);
     return;
   }
+  logger.debug(`Winners map: ${WINNERS}`)
   let players = [...WINNERS.get(id)];
+  logger.debug(`Found ${players.length} players in party`)
 
   //remove so we don't get duplicate response(s)
   WINNERS.delete(id);
@@ -160,7 +169,7 @@ const handleWin = async(presence, channel) => {
     await sendMessage(spectators, channel, true);
   }
 
-  sendStats(players, channel);
+  sendStats(players, channel, id);
 }
 
 /**
@@ -219,12 +228,22 @@ const getRandomResponse = (spectator) => {
  * @param {*} players 
  * @param {*} channel 
  */
-const sendStats = async(players, channel) => {
+const sendStats = async(players, channel, partyId) => {
   if(process.env.PUBG_API_KEY && process.env.PUBG_API_KEY !== ''){
-    await autoStats(players, channel);
+    let presenceId = extractPUBGIdFromPartyId(partyId);
+    await autoStats(players, channel, presenceId);
   }else{
     logger.debug('PUBG API key missing, auto stats skipped')
   }
+}
+
+const extractPUBGIdFromPartyId = (partyId) => {
+  if(partyId.includes('account') && partyId.includes('-')){
+    let ID = test.split('-').shift();
+    logger.debug(`Extracted ${ID} from party Id`);
+    return ID;
+  }
+  return null;
 }
 
 module.exports = {

--- a/lib/events/presence.js
+++ b/lib/events/presence.js
@@ -239,7 +239,7 @@ const sendStats = async(players, channel, partyId) => {
 
 const extractPUBGIdFromPartyId = (partyId) => {
   if(partyId.includes('account') && partyId.includes('-')){
-    let ID = test.split('-').shift();
+    let ID = partyId.split('-').shift();
     logger.debug(`Extracted ${ID} from party Id`);
     return ID;
   }

--- a/lib/events/presence.js
+++ b/lib/events/presence.js
@@ -21,8 +21,6 @@ const presenceUpdate = async(old, updated) => {
 
     if(!newPresence.details || !oldPresence.details) return;
 
-    logger.debug(`PUBG presence found: ${JSON.stringify(newPresence)}`);
-
     const match = {
       user: updated.user,
       old: oldPresence,
@@ -30,10 +28,12 @@ const presenceUpdate = async(old, updated) => {
     }
     //new presence is a win...
     if (newPresence.details.includes(WINNER_WINNER)) {
+      logger.debug(`PUBG presence found: ${JSON.stringify(newPresence)}`);
       detectWin(match);
     }
     //players have left winner screen, send message
     else if (oldPresence.details.includes(WINNER_WINNER) && !newPresence.details.includes(WINNER_WINNER)) {
+      logger.debug(`PUBG presence found: ${JSON.stringify(newPresence)}`);
       const channel = updated.guild.channels.cache.get(process.env.CHANNEL_ID);
       await handleWin(match, channel);
     }
@@ -69,11 +69,11 @@ const getPUBGPresence = (old, updated) => {
 
 /**
  * Detect and save winners based on presence
- * @param {*} presence 
+ * @param {*} match 
  * @returns 
  */
-const detectWin = (presence) => {
-  const {user, old, updated} = presence;
+const detectWin = (match) => {
+  const {user, old, updated} = match;
   logger.log(`Win detected by presence, pre-exclude: ${updated.details}`);
   if(!isValidMap(updated.details)){
     return;
@@ -136,12 +136,12 @@ const isValidMap = (details) => {
 
 /**
  * Send message to winners
- * @param {*} presence 
+ * @param {*} match 
  * @param {*} channel 
  * @returns 
  */
-const handleWin = async(presence, channel) => {
-  const {user, old, updated} = presence;
+const handleWin = async(match, channel) => {
+  const {user, old, updated} = match;
   if(!isValidMap(updated.details)){
     return;
   }

--- a/lib/events/presence.js
+++ b/lib/events/presence.js
@@ -142,7 +142,7 @@ const isValidMap = (details) => {
  */
 const handleWin = async(match, channel) => {
   const {user, old, updated} = match;
-  if(!isValidMap(updated.details)){
+  if(!isValidMap(old.details)){
     return;
   }
   logger.log(`Post win for ${user.username}: [${old.details}] => [${updated.details}]`);

--- a/lib/pubg.js
+++ b/lib/pubg.js
@@ -202,6 +202,7 @@ const getMatch = async (matchId, player) => {
     });
 
     return {
+        name: matchPlayer.attributes.stats.name,
         matchId: matchId,
         mode: data.attributes.gameMode,
         date: data.attributes.createdAt,

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -35,8 +35,8 @@ const isRecentWin = (date, min = 45) => {
  * @param {*} channel - Discord TextChannel 
  * @param {*} statusMessage - Message sent to inform user stats are incoming
  */
-const sendWinningStats = async(stats, user, channel, statusMessage) => {
-  const embed = await createWinningStatEmbed(stats, user.pubg_username, stats.team.length > 0);
+const sendWinningStats = async(stats, channel, statusMessage) => {
+  const embed = await createWinningStatEmbed(stats, stats.team.length > 0);
   statusMessage.delete();
   channel.send(embed);
 }
@@ -121,26 +121,40 @@ const findRecentStats = async(pubId, statusMessage) => {
  * @param {*} winners list of users
  * @param {*} channel discord channel 
  */
-const autoStats = async(winners, channel) => {
+const autoStats = async(winners, channel, presenceId) => {
   try{
     //grab pubg_id so we can lookup stats
-    let user = await findPUBGUserFromList(winners.map(winner => winner.user.id));
-    if(user){
-      logger.log(`PUBG ID found for a winner (${user.username}), querying stats...`);
+    let pubgId = await getPUBGId(winners, presenceId);
+    if(pubgId){
+      logger.log(`Got ID, querying stats...`);
       let statusMessage = await channel.send(`Winning stats incoming... :timer:`);
 
       try{
-        let stats = await findRecentStats(user.pubg_id, statusMessage);
-        await sendWinningStats(stats, user, channel, statusMessage);
+        let stats = await findRecentStats(pubgId, statusMessage);
+        await sendWinningStats(stats, channel, statusMessage);
       }catch(err){
         //stats not found
       }
     }else{
-      logger.log(`No PUBG IDs found amoung winners, no stats`)
+      logger.log(`No PUBG IDs found, no stats`)
     }
   }catch(e){
     logger.error(e);
   }
+}
+
+const getPUBGId = async(winners, presenceId) => {
+  if(presenceId){
+    logger.log(`Using presence found in partyId: ${presenceId}`)
+    return presenceId;
+  }else{
+    let user = await findPUBGUserFromList(winners.map(winner => winner.user.id));
+    if(user){
+      logger.log(`PUBG ID found among winners (${user.username}): ${user.pubg_id}`)
+      return user.pubg_id;
+    }
+  }
+  return null;
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dinner-bot",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dinner-bot",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dinner-bot",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Discord bot to track PUBG wins",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
- extract users PUBG ID from Discord Presence object
- Add extra logging to help debug duplicate messages