### PR TITLE
Fix(stats): isRecent logic

### DIFF
--- a/lib/pubg.js
+++ b/lib/pubg.js
@@ -87,7 +87,7 @@ const getLatestWin = async(playerId) => {
             return getMatch(match, player.id);
         }));
         const winning = results.filter(match => {
-            return match.place == 1;
+            return match.place == 1 && match.matchType === 'official';
         });
         if(winning.length === 0){
             logger.debug(`No win found in last 50 matches`)
@@ -206,7 +206,9 @@ const getMatch = async (matchId, player) => {
     return {
         name: matchPlayer.attributes.stats.name,
         matchId: matchId,
+        duration: data.attributes.duration,
         mode: data.attributes.gameMode,
+        matchType: data.attributes.matchType,
         date: data.attributes.createdAt,
         map: validateMapName(data.attributes.mapName),
         place: team.attributes.stats.rank,

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -14,26 +14,48 @@ const {getTimestamp} = require('./utils');
  * @param {*} min number of minutes considered recent
  * @returns 
  */
-const isRecentWin = (date, min = 45) => {
-    if(!date){
+const isRecentWin = (stats, min = 45) => {
+    if(!stats?.date){
       logger.debug(`Date not provided, not recent`);
       return false;
     }
-    const end = new Date();
-    const start = sub(new Date(), {
-      minutes: min
-    });
-    const statDate = new Date(date);
-    if(isWithinInterval(statDate, {
-      start,
-      end
-    })){
-      logger.debug(`Stat date is within last ${min} min`);
-      return true;
+    if(stats?.duration){
+      const THRESHOLD_IN_MIN = 5;
+      logger.debug(`Calculating endtime based on start and duration`);
+      const endTime = calculateEndTime(stats.date, stats.duration);
+      logger.debug(`EndTime: ${endTime}`);
+      const lastXMin = new Date(Date.now() - ((THRESHOLD_IN_MIN * 1000) * 60));
+      logger.debug(`Now: ${lastXMin}`)
+      if(endTime.getTime() > lastXMin.getTime()){
+        logger.debug(`Match end time within last ${THRESHOLD_IN_MIN} min`);
+        return true;
+      }else{
+        logger.debug(`Match end time NOT within last ${THRESHOLD_IN_MIN} min`);
+        return false;
+      }
     }else{
-      logger.debug(`Stat date NOT within last ${min} min: ${getTimestamp(statDate)}`);
-      return false;
+      logger.debug('Missing duration, calculating based on startTime');
+      const end = new Date();
+      const start = sub(new Date(), {
+        minutes: min
+      });
+      const statDate = new Date(date);
+      if(isWithinInterval(statDate, {
+        start,
+        end
+      })){
+        logger.debug(`Stat date is within last ${min} min`);
+        return true;
+      }else{
+        logger.debug(`Stat date NOT within last ${min} min: ${getTimestamp(statDate)}`);
+        return false;
+      }
     }
+}
+
+const calculateEndTime = (start, duration) => {
+  const startTime = new Date(start);
+  return new Date(startTime.getTime() + (duration * 1000));
 }
 
 /**
@@ -71,7 +93,7 @@ const queryStats = async(pubgId) => {
   let stats = await getLatestWin(pubgId);
   return {
     stats,
-    recent: isRecentWin(stats?.date)
+    recent: isRecentWin(stats)
   }
 }
 

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -64,10 +64,10 @@ const isRecentByStartTime = (startDate, min = 45) => {
     start,
     end
   })){
-    logger.debug(`Stat date is within last ${min} min`);
+    logger.debug(`Stat date (${statDate}) within last ${min} min`);
     return true;
   }else{
-    logger.debug(`Stat date NOT within last ${min} min: ${getTimestamp(statDate)}`);
+    logger.debug(`Stat date (${statDate}) NOT within last ${min} min`);
     return false;
   }
 }

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -27,8 +27,8 @@ const isRecentWin = (stats) => {
 
 /**
  * Determines if recent by calculating endtime based on start date and duration
- * @param {*} startDate 
- * @param {*} duration 
+ * @param {*} startDate - ISO string format
+ * @param {*} duration - in seconds
  * @returns true if recent
  */
 const isRecentByDuration = (startDate, duration) => {

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -9,50 +9,75 @@ const {STATS} = require('./constants');
 const {getTimestamp} = require('./utils');
 
 /**
- * Determine if most recent win is within last X minutes
- * @param {*} date date of win
- * @param {*} min number of minutes considered recent
- * @returns 
+ * Determine if found win is recent
+ * @param {*} stats - PUBG stats object
+ * @returns true if recent, otherwise false
  */
-const isRecentWin = (stats, min = 45) => {
+const isRecentWin = (stats) => {
     if(!stats?.date){
       logger.debug(`Date not provided, not recent`);
       return false;
     }
     if(stats?.duration){
-      const THRESHOLD_IN_MIN = 5;
-      logger.debug(`Calculating endtime based on start and duration`);
-      const endTime = calculateEndTime(stats.date, stats.duration);
-      logger.debug(`EndTime: ${endTime}`);
-      const lastXMin = new Date(Date.now() - ((THRESHOLD_IN_MIN * 1000) * 60));
-      logger.debug(`Now: ${lastXMin}`)
-      if(endTime.getTime() > lastXMin.getTime()){
-        logger.debug(`Match end time within last ${THRESHOLD_IN_MIN} min`);
-        return true;
-      }else{
-        logger.debug(`Match end time NOT within last ${THRESHOLD_IN_MIN} min`);
-        return false;
-      }
+      return isRecentByDuration(stats.date, stats.duration);
     }else{
-      logger.debug('Missing duration, calculating based on startTime');
-      const end = new Date();
-      const start = sub(new Date(), {
-        minutes: min
-      });
-      const statDate = new Date(date);
-      if(isWithinInterval(statDate, {
-        start,
-        end
-      })){
-        logger.debug(`Stat date is within last ${min} min`);
-        return true;
-      }else{
-        logger.debug(`Stat date NOT within last ${min} min: ${getTimestamp(statDate)}`);
-        return false;
-      }
+      return isRecentByStartTime(stats.date);
     }
 }
 
+/**
+ * Determines if recent by calculating endtime based on start date and duration
+ * @param {*} startDate 
+ * @param {*} duration 
+ * @returns true if recent
+ */
+const isRecentByDuration = (startDate, duration) => {
+  const THRESHOLD_IN_MIN = 5;
+  logger.debug(`Calculating endtime based on start and duration`);
+  const endTime = calculateEndTime(startDate, duration);
+  logger.debug(`EndTime: ${endTime}`);
+  const lastXMin = new Date(Date.now() - ((THRESHOLD_IN_MIN * 1000) * 60));
+  logger.debug(`Now: ${lastXMin}`)
+  if(endTime.getTime() > lastXMin.getTime()){
+    logger.debug(`Match end time within last ${THRESHOLD_IN_MIN} min`);
+    return true;
+  }else{
+    logger.debug(`Match end time NOT within last ${THRESHOLD_IN_MIN} min`);
+    return false;
+  }
+}
+
+/**
+ * Determines if recent by checking if startDate is withing last X min (default 45 min)
+ * @param {*} startDate - start date of match
+ * @param {*} min - considered recent if within last
+ * @returns 
+ */
+const isRecentByStartTime = (startDate, min = 45) => {
+  logger.debug('Missing duration, calculating based on startTime');
+  const end = new Date();
+  const start = sub(new Date(), {
+    minutes: min
+  });
+  const statDate = new Date(startDate);
+  if(isWithinInterval(statDate, {
+    start,
+    end
+  })){
+    logger.debug(`Stat date is within last ${min} min`);
+    return true;
+  }else{
+    logger.debug(`Stat date NOT within last ${min} min: ${getTimestamp(statDate)}`);
+    return false;
+  }
+}
+
+/**
+ * Calculate endtime give start time and duration
+ * @param {*} start - start time in ISO string format
+ * @param {*} duration - in seconds
+ * @returns 
+ */
 const calculateEndTime = (start, duration) => {
   const startTime = new Date(start);
   return new Date(startTime.getTime() + (duration * 1000));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dinner-bot",
-  "version": "4.8.8",
+  "version": "4.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dinner-bot",
-  "version": "4.8.8",
+  "version": "4.9.0",
   "description": "Discord bot to track PUBG wins",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Adjust `isRecent` logic to use match start time and duration to calculate a smaller, more accurate match end time. This resolves an issue where a user has won two games in a row. The current logic would find the first win is recent "enough" (within last 45 min) and use those stats instead of waiting for the new, second win. 

- Use duration to calculate approx match end time
- Filter out non-official matchTypes (custom, arcade, event, etc) when querying for wins